### PR TITLE
Add direct link for bookmarks file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supports Kubernetes v1.19
 
 Steps to use the bookmark :
 
--  Right Click on the file ```kubernetes.io.html``` and ``` Save link as```, save the file to your local drive.
+-  Right Click on the file: [kubernetes.io.html](https://raw.githubusercontent.com/reetasingh/CKAD-Bookmarks/master/kubernetes.io.html) and click ``` Save link as``` to save the bookmarks file to your local drive.
 -  On the Chrome Browser, click the three dots at the top right, go to ```Bookmarks``` and click the ```Import bookmarks and settings..```.
 -  Select ```Bookmarks HTML file``` file from the drop-down menu.
 -  ```Choose file``` and select the previously downloaded file, click ```Open```.


### PR DESCRIPTION
Hi there! I have a small fix for an issue I faced trying to download and install the bookmarks (thanks for these awesome bookmarks btw 🤩)

At some point GitHub must have changed the way the link was represented because when I followed the current instructions on Microsoft Edge (Chromium-based browser) the following bookmarks were imported:
![image](https://user-images.githubusercontent.com/8005593/206127751-15982c47-a395-45ba-9ea5-a4172684c220.png)

Embedding a direct link to the file in the markdown readme works:
![image](https://user-images.githubusercontent.com/8005593/206127991-c0553ac5-4eab-4196-9261-d4f7dafe61d8.png)

----
Considerations

* Since it's a direct link, if the default branch is changed (or the file is moved) the link will then need to be updated. I figure most likely it will be easier for users to download the file directly from the link rather than navigate to the file to download its contents.

* This may help with issue #2 since the file didn't seem to be downloading as expected